### PR TITLE
Check against nullable final swipe offset #1

### DIFF
--- a/lib/simple_gesture_detector.dart
+++ b/lib/simple_gesture_detector.dart
@@ -60,6 +60,10 @@ class _SimpleGestureDetectorState extends State<SimpleGestureDetector> {
   Offset _finalSwipeOffset;
   SwipeDirection _previousDirection;
 
+  bool _isSwipeValid() {
+    return _initialSwipeOffset != null && _finalSwipeOffset != null;
+  }
+
   void _onVerticalDragStart(DragStartDetails details) {
     _initialSwipeOffset = details.globalPosition;
   }
@@ -71,7 +75,7 @@ class _SimpleGestureDetectorState extends State<SimpleGestureDetector> {
       return;
     }
 
-    if (_initialSwipeOffset != null) {
+    if (_isSwipeValid()) {
       final offsetDifference = _initialSwipeOffset.dy - _finalSwipeOffset.dy;
 
       if (offsetDifference.abs() > widget.swipeConfig.verticalThreshold) {
@@ -92,7 +96,7 @@ class _SimpleGestureDetectorState extends State<SimpleGestureDetector> {
 
   void _onVerticalDragEnd(DragEndDetails details) {
     if (widget.swipeConfig.swipeDetectionBehavior == SwipeDetectionBehavior.singularOnEnd) {
-      if (_initialSwipeOffset != null) {
+      if (_isSwipeValid()) {
         final offsetDifference = _initialSwipeOffset.dy - _finalSwipeOffset.dy;
 
         if (offsetDifference.abs() > widget.swipeConfig.verticalThreshold) {
@@ -117,7 +121,7 @@ class _SimpleGestureDetectorState extends State<SimpleGestureDetector> {
       return;
     }
 
-    if (_initialSwipeOffset != null) {
+    if (_isSwipeValid()) {
       final offsetDifference = _initialSwipeOffset.dx - _finalSwipeOffset.dx;
 
       if (offsetDifference.abs() > widget.swipeConfig.horizontalThreshold) {
@@ -138,7 +142,7 @@ class _SimpleGestureDetectorState extends State<SimpleGestureDetector> {
 
   void _onHorizontalDragEnd(DragEndDetails details) {
     if (widget.swipeConfig.swipeDetectionBehavior == SwipeDetectionBehavior.singularOnEnd) {
-      if (_initialSwipeOffset != null) {
+      if (_isSwipeValid()) {
         final offsetDifference = _initialSwipeOffset.dx - _finalSwipeOffset.dx;
 
         if (offsetDifference.abs() > widget.swipeConfig.horizontalThreshold) {


### PR DESCRIPTION
Fixes https://github.com/aleksanderwozniak/simple_gesture_detector/issues/1

For me it's impossible to reproduce the issue locally, but as other users already reported (and my own Crashlytics) - it's definitely possible on end users devices.

From the sole code perspective it seems impossible to reach such state (`update` not called between `start` and `end`), but well, that's a software world. 